### PR TITLE
Fix typos in test name and scheduler comment

### DIFF
--- a/include/holoscan/core/executors/gxf/gxf_executor.hpp
+++ b/include/holoscan/core/executors/gxf/gxf_executor.hpp
@@ -268,7 +268,7 @@ class GXFExecutor : public holoscan::Executor {
   /** @brief Initialize all GXF Resources in the map and assign them to graph_entity.
    *
    *  Utility function grouping common code across `initialize_network_context` and
-   *  `intialize_scheduler`.
+   *  `initialize_scheduler`.
    *
    * @param resources Unordered map of GXF resources.
    * @param eid The entity to which the resources will be assigned.

--- a/python/tests/unit/test_resources.py
+++ b/python/tests/unit/test_resources.py
@@ -458,7 +458,7 @@ class TestUcxHoloscanComponentSerializer:
 
 
 class TestUcxEntitySerializer:
-    def test_intialization_default_serializers(self, app, capfd):
+    def test_initialization_default_serializers(self, app, capfd):
         name = "ucx_entity_serializer"
         res = UcxEntitySerializer(
             fragment=app,


### PR DESCRIPTION
## Summary
- fix test typo `test_initialization_default_serializers`
- correct comment spelling in `gxf_executor.hpp`

## Testing
- `./run lint python/tests/unit/test_resources.py include/holoscan/core/executors/gxf/gxf_executor.hpp` *(fails: cpplint/codespell missing)*
- `cmake -B build -S . -DHOLOSCAN_BUILD_TESTS=ON` *(fails: missing RAPIDS modules and CUDA toolkit)*